### PR TITLE
Feature/extend tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "task/phpspec": "~0.1",
+        "mikey179/vfsStream": "~1.2",
         "henrikbjorn/phpspec-code-coverage" : "1.0.*@dev"
     },
     "autoload": {

--- a/src/Project.php
+++ b/src/Project.php
@@ -85,7 +85,12 @@ class Project extends Application
     public function extend($path)
     {
         $extend = require $path;
-        return $extend($this);
+
+        if (!is_callable($extend)) {
+            throw new \InvalidArgumentException("Extension script should return callable!");
+        }
+
+        return call_user_func($extend, $this);
     }
 
     public function parseArguments(array $args)


### PR DESCRIPTION
Changes Made:
- Included vfsStream within the require-dev block for mocking the filesystem in some tests
- Additions to ProjectSpec to include extend in code coverage
- Updated Project extend fn to check that closure is callable, and throw InvalidArgumentExtension otherwise
- Use call_user_func to invoke closure
